### PR TITLE
allow build on windows, disabling syslog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/devopsfaith/krakend-gologging
+
+go 1.12

--- a/log_windows.go
+++ b/log_windows.go
@@ -1,4 +1,4 @@
-// +build !windows, !plan9
+// +build windows, plan9
 
 //Package gologging provides a logger implementation based on the github.com/op/go-logging pkg
 package gologging
@@ -43,9 +43,6 @@ func NewLogger(cfg config.ExtraConfig, ws ...io.Writer) (logging.Logger, error) 
 
 	if logConfig.StdOut {
 		ws = append(ws, os.Stdout)
-	}
-
-	if logConfig.Syslog {
 	}
 
 	if logConfig.Format == "logstash" {


### PR DESCRIPTION
To merge code from https://github.com/willie68/krakend-gologging/tree/allow_windows_build to allow building krakend-ce from windows. Need to undo changes to `log.go` after merge.